### PR TITLE
Provide global configuration mechanism

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ def my_function(a: int, b: str, c: float):
     # Function code here...
 ```
 
-It is also possible to specify a value for `ignored_parameters` which will be used for all decorated functions
+It is also possible to specify a value for `ignore_parameters` which will be used for all decorated functions
 unless explicitly overridden. It can be done by editing the global configuration as follows:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -158,3 +158,14 @@ You can check if a function has a certain tag using the `has_tag` method.
 ```python
 my_function.has_tag("tag1")  # True
 ```
+
+### Disable parts of the schema
+
+You can provide `GPTEnabled` with a list of parameters to ignore, which will be omitted from the schema.
+For example:
+
+```python
+@GPTEnabled(ignore_parameters=["b", "c"])  # b and c will not be included in the schema
+def my_function(a: int, b: str, c: float):
+    # Function code here...
+```

--- a/README.md
+++ b/README.md
@@ -214,3 +214,13 @@ For example:
 def my_function(a: int, b: str, c: float):
     # Function code here...
 ```
+
+It is also possible to specify a value for `ignored_parameters` which will be used for all decorated functions
+unless explicitly overridden. It can be done by editing the global configuration as follows:
+
+```python
+import tool2schema
+
+# Ignore all parameters named "a" or "b" by default
+tool2schema.CONFIG.ignore_parameters = ["a", "b"]
+```

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -767,3 +767,21 @@ def test_global_configuration_ignore_parameters():
     assert _function.tags == []
 
     tool2schema.CONFIG.reset_default()
+
+
+#######################
+#  Test Config class  #
+#######################
+
+
+def test_reset_config():
+    config = tool2schema.config.Config(ignore_parameters=["a"])
+    config.reset_default()  # Should not reset the arguments given in the constructor
+    assert config.ignore_parameters == ["a"]
+
+
+def test_reset_config_edit_list():
+    config = tool2schema.config.Config(ignore_parameters=["a", "b"])
+    config.ignore_parameters = ["c", "d"]
+    config.reset_default()
+    assert config.ignore_parameters == ["a", "b"]

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -710,12 +710,12 @@ def test_function_custom_enum_default_value():
 
 
 #############################
-#  Test ignored_parameters  #
+#  Test ignore_parameters  #
 #############################
 
 
-@GPTEnabled(ignored_parameters=["a", "d"])
-def function_ignored_parameters(a: int, b: str, c: bool = False, d: list[int] = [1, 2, 3]):
+@GPTEnabled(ignore_parameters=["a", "d"])
+def function_ignore_parameters(a: int, b: str, c: bool = False, d: list[int] = [1, 2, 3]):
     """
     This is a test function.
 
@@ -727,13 +727,13 @@ def function_ignored_parameters(a: int, b: str, c: bool = False, d: list[int] = 
     return a, b, c, d
 
 
-def test_function_ignored_parameters():
-    rf = ReferenceSchema(function_ignored_parameters)
+def test_function_ignore_parameters():
+    rf = ReferenceSchema(function_ignore_parameters)
     rf.remove_param("a")
     rf.remove_param("d")
-    assert function_ignored_parameters.schema.to_json() == rf.schema
-    assert function_ignored_parameters.schema.to_json(SchemaType.TUNE) == rf.tune_schema
-    assert function_ignored_parameters.tags == []
+    assert function_ignore_parameters.schema.to_json() == rf.schema
+    assert function_ignore_parameters.schema.to_json(SchemaType.TUNE) == rf.tune_schema
+    assert function_ignore_parameters.tags == []
 
 
 ###############################
@@ -741,9 +741,9 @@ def test_function_ignored_parameters():
 ###############################
 
 
-def test_global_configuration_ignored_parameters():
+def test_global_configuration_ignore_parameters():
     # Change the global configuration
-    tool2schema.CONFIG.ignored_parameters = ["b", "c"]
+    tool2schema.CONFIG.ignore_parameters = ["b", "c"]
 
     # We have to re-define the function in this scope
     # to use the updated configuration

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -759,10 +759,11 @@ def test_global_configuration_ignore_parameters():
         """
         return a, b, c, d
 
-    tool2schema.CONFIG.reset_default()
     rf = ReferenceSchema(_function)
     rf.remove_param("b")
     rf.remove_param("c")
     assert _function.schema.to_json() == rf.schema
     assert _function.schema.to_json(SchemaType.TUNE) == rf.tune_schema
     assert _function.tags == []
+
+    tool2schema.CONFIG.reset_default()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -759,7 +759,7 @@ def test_global_configuration_ignore_parameters():
         """
         return a, b, c, d
 
-    tool2schema._reset_config()  # Reset the configuration to the default
+    tool2schema.CONFIG.reset_default()
     rf = ReferenceSchema(_function)
     rf.remove_param("b")
     rf.remove_param("c")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -741,7 +741,7 @@ def test_function_ignored_parameters():
 ###############################
 
 
-def test_global_configuration_ignored_args():
+def test_global_configuration_ignored_parameters():
     # Change the global configuration
     tool2schema.CONFIG.ignored_parameters = ["b", "c"]
 

--- a/tool2schema/__init__.py
+++ b/tool2schema/__init__.py
@@ -10,3 +10,16 @@ from .schema import (
     SaveGPTEnabled,
     SchemaType,
 )
+
+from .config import Config
+
+# Default global configuration
+CONFIG = Config()
+
+
+def _reset_config():
+    """
+    Reset the configuration to the default settings.
+    """
+    global CONFIG
+    CONFIG = Config()

--- a/tool2schema/__init__.py
+++ b/tool2schema/__init__.py
@@ -14,11 +14,3 @@ from .schema import (
 
 # Default global configuration
 CONFIG = Config()
-
-
-def _reset_config():
-    """
-    Reset the configuration to the default settings.
-    """
-    global CONFIG
-    CONFIG = Config()

--- a/tool2schema/__init__.py
+++ b/tool2schema/__init__.py
@@ -13,4 +13,4 @@ from .schema import (
 )
 
 # Default global configuration
-CONFIG = Config()
+CONFIG: Config = Config()

--- a/tool2schema/__init__.py
+++ b/tool2schema/__init__.py
@@ -13,4 +13,4 @@ from .schema import (
 )
 
 # Default global configuration
-CONFIG: Config = Config()
+CONFIG = Config()

--- a/tool2schema/config.py
+++ b/tool2schema/config.py
@@ -9,11 +9,25 @@ class Config:
     """
 
     def __init__(self, parent: Optional[Config] = None, **settings):
-        self.parent = parent
-        self.settings = settings
-        self.ignore_parameters: list[str] = self._get_setting(
-            "ignore_parameters", ["self", "args", "kwargs"]
-        )
+        self._parent = parent
+        self._settings = settings
+
+    @property
+    def ignore_parameters(self) -> list[str]:
+        """
+        List of parameter names to ignore when creating a schema.
+        """
+        return self._get_setting(Config.ignore_parameters.fget.__name__, ["self", "args", "kwargs"])
+
+    @ignore_parameters.setter
+    def ignore_parameters(self, value: list[str]):
+        self._set_setting(Config.ignore_parameters.fget.__name__, value)
+
+    def reset_default(self):
+        """
+        Reset the configuration to the default settings.
+        """
+        self._settings = {}
 
     def _get_setting(self, name: str, default):
         """
@@ -25,7 +39,14 @@ class Config:
             the settings dictionary and this configuration has no parent
         :return: The requested setting value
         """
-        if not self.parent:
-            return self.settings.pop(name, default)
+        fallback = default if not self._parent else getattr(self._parent, name)
+        return self._settings.get(name, fallback)
 
-        return self.settings.pop(name, getattr(self.parent, name))
+    def _set_setting(self, name: str, value):
+        """
+        Set a setting value in the settings dictionary.
+
+        :param name: Name of the setting
+        :param value: Value to set
+        """
+        self._settings[name] = value

--- a/tool2schema/config.py
+++ b/tool2schema/config.py
@@ -11,8 +11,8 @@ class Config:
     def __init__(self, parent: Optional[Config] = None, **settings):
         self.parent = parent
         self.settings = settings
-        self.ignored_parameters: list[str] = self._get_setting(
-            "ignored_parameters", ["self", "args", "kwargs"]
+        self.ignore_parameters: list[str] = self._get_setting(
+            "ignore_parameters", ["self", "args", "kwargs"]
         )
 
     def _get_setting(self, name: str, default):

--- a/tool2schema/config.py
+++ b/tool2schema/config.py
@@ -11,7 +11,6 @@ class Config:
     def __init__(self, parent: Optional[Config] = None, **settings):
         self.parent = parent
         self.settings = settings
-        self.tags: list[str] = self._get_setting("tags", [])
         self.ignored_parameters: list[str] = self._get_setting(
             "ignored_parameters", ["self", "args", "kwargs"]
         )

--- a/tool2schema/config.py
+++ b/tool2schema/config.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+from typing import Optional
+
+
+class Config:
+    """
+    Configuration class for tool2schema.
+    """
+
+    def __init__(self, parent: Optional[Config] = None, **settings):
+        self.parent = parent
+        self.settings = settings
+        self.tags: list[str] = self._get_setting("tags", [])
+        self.ignored_parameters: list[str] = self._get_setting(
+            "ignored_parameters", ["self", "args", "kwargs"]
+        )
+
+    def _get_setting(self, name: str, default):
+        """
+        Get a setting value from the settings dictionary or the parent configuration.
+        If not found, return the default value.
+
+        :param name: Name of the setting
+        :param default: Default value, used when the setting is not found in
+            the settings dictionary and this configuration has no parent
+        :return: The requested setting value
+        """
+        if not self.parent:
+            return self.settings.pop(name, default)
+
+        return self.settings.pop(name, getattr(self.parent, name))

--- a/tool2schema/config.py
+++ b/tool2schema/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from typing import Optional
 
 
@@ -11,6 +12,7 @@ class Config:
     def __init__(self, parent: Optional[Config] = None, **settings):
         self._parent = parent
         self._settings = settings
+        self._initial_settings = copy.deepcopy(settings)
 
     @property
     def ignore_parameters(self) -> list[str]:
@@ -27,7 +29,7 @@ class Config:
         """
         Reset the configuration to the default settings.
         """
-        self._settings = {}
+        self._settings = copy.deepcopy(self._initial_settings)
 
     def _get_setting(self, name: str, default):
         """

--- a/tool2schema/schema.py
+++ b/tool2schema/schema.py
@@ -214,7 +214,7 @@ class FunctionSchema:
         parameters = dict()
 
         for i, (n, o) in enumerate(inspect.signature(self.f).parameters.items()):
-            if n in self.config.ignored_parameters:
+            if n in self.config.ignore_parameters:
                 continue  # Skip ignored parameter
 
             for Param in PARAMETER_SCHEMAS:

--- a/tool2schema/schema.py
+++ b/tool2schema/schema.py
@@ -78,6 +78,7 @@ def SaveGPTEnabled(module: ModuleType, path: str, schema_type: SchemaType = Sche
 class _GPTEnabled:
     def __init__(self, func, **kwargs) -> None:
         self.func = func
+        self.tags = kwargs.pop("tags", [])
         self.config = Config(tool2schema.CONFIG, **kwargs)
         self.schema = FunctionSchema(func, self.config)
         functools.update_wrapper(self, func)
@@ -98,10 +99,6 @@ class _GPTEnabled:
                 kwargs[key] = self.schema.parameter_schemas[key].decode_value(kwargs[key])
 
         return self.func(*args, **kwargs)
-
-    @property
-    def tags(self):
-        return self.config.tags
 
     def gpt_enabled(self) -> bool:
         return True


### PR DESCRIPTION
Issue #34

This solution uses a `Config` class defining as attributes the tool2schema-related settings. Currently, the available settings are `tags` and `ignored_parameters`.

```python
class Config:
    """
    Configuration class for tool2schema.
    """

    def __init__(self, parent: Optional[Config] = None, **settings):
        self.parent = parent
        self.settings = settings
        self.tags: list[str] = self._get_setting("tags", [])
        self.ignored_parameters: list[str] = self._get_setting(
            "ignored_parameters", ["self", "args", "kwargs"]
        )

    def _get_setting(self, name: str, default):
        if not self.parent:
            return self.settings.pop(name, default)

        return self.settings.pop(name, getattr(self.parent, name))
```

By creating an instance of `Config` without any additional parameters one gets the default configuration. 
The default values are specified in the constructor and passed to `_get_setting`. 

The `Config` class can accept a parent configuration which is used (if present) to retrieve the settings that are not overridden by keyword arguments. 

In the following example, `my_config` will have the same settings as the parent `parent_config`, except for `tags` which will be overridden.

```python
my_config = Config(parent_config, tags=["hello"])
```

In  `__init__.py` an instance of `Config` is created to serve as the global configuration:
```python
# Default global configuration
CONFIG = Config()
```

This allows the user to edit the settings as follows:
```python
import tool2schema

tool2schema.CONFIG.ignored_parameters = ["b", "c"]
```