### PR TITLE
Support nested types

### DIFF
--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -826,6 +826,10 @@ def test_function_custom_enum_list():
     _, _, _, d = function_custom_enum_list(1, "", False, d=[CustomEnum.A])
     assert d == [CustomEnum.A]
 
+    # Verify it works with keyword an empty list
+    _, _, _, d = function_custom_enum_list(1, "", False, d=[])
+    assert d == []
+
 
 ###########################
 #  Test ignore_parameters #

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -788,7 +788,7 @@ def function_custom_enum_list(
     a: int,
     b: str,
     c: bool = False,
-    d: list[CustomEnum] = [CustomEnum.A, CustomEnum.B, CustomEnum.C],
+    d: list[CustomEnum] = [CustomEnum.A, CustomEnum.B],
 ):
     """
     This is a test function.
@@ -804,8 +804,8 @@ def function_custom_enum_list(
 def test_function_custom_enum_list():
     rf = ReferenceSchema(function_custom_enum_list)
     b = rf.get_param("d")
-    b["default"] = ["A", "B", "C"]
-    b["items"]["type"] = "string"
+    b["default"] = ["A", "B"]
+    b["items"] = {"type": "string", "enum": ["A", "B", "C"]}
 
     assert function_custom_enum_list.schema.to_json() == rf.schema
     assert function_custom_enum_list.tags == []

--- a/tool2schema/parameter_schema.py
+++ b/tool2schema/parameter_schema.py
@@ -10,8 +10,8 @@ from tool2schema.type_schema import EnumTypeSchema, TypeSchema
 
 class ParameterSchema:
     """
-    Automatically create a parameter schema given an instance of
-    inspect.Parameter and a function documentation string.
+    Automatically create a parameter schema given an instance of inspect.Parameter
+    and a function documentation string.
     """
 
     def __init__(
@@ -28,6 +28,7 @@ class ParameterSchema:
         :param type_schema: The type schema for the parameter (use `TypeSchema.create`)
         :param parameter: The parameter to create a schema for
         :param index: The index of the parameter in the function signature
+        :param config: Configuration settings to use when creating the schema
         :param docstring: The docstring for the function containing the parameter
         """
         self.type_schema = type_schema
@@ -43,6 +44,10 @@ class ParameterSchema:
         """
         Create a new parameter schema for the specified parameter.
 
+        :param parameter: The parameter to create a schema for
+        :param index: The index of the parameter in the function signature
+        :param docstring: The docstring for the function containing the parameter
+        :param config: Configuration settings to use when creating the schema
         :return: An instance of `ParameterSchema`, or None if the parameter type is not supported.
         """
         if type_schema := TypeSchema.create(parameter.annotation):

--- a/tool2schema/parameter_schema.py
+++ b/tool2schema/parameter_schema.py
@@ -1,18 +1,11 @@
+from __future__ import annotations
+
 import re
-import typing
-from enum import Enum
-from inspect import Parameter, isclass
-from typing import Union
+from inspect import Parameter
+from typing import Optional, Union
 
 from tool2schema import Config
-
-TYPE_MAP = {
-    "int": "integer",
-    "float": "number",
-    "str": "string",
-    "bool": "boolean",
-    "list": "array",
-}
+from tool2schema.type_schema import EnumTypeSchema, TypeSchema
 
 
 class ParameterSchema:
@@ -21,48 +14,39 @@ class ParameterSchema:
     inspect.Parameter and a function documentation string.
     """
 
-    def __init__(self, parameter: Parameter, index: int, config: Config, docstring: str = None):
+    def __init__(
+        self,
+        type_schema: TypeSchema,
+        parameter: Parameter,
+        index: int,
+        config: Config,
+        docstring: str = None,
+    ):
         """
         Create a new parameter schema.
 
+        :param type_schema: The type schema for the parameter (use `TypeSchema.create`)
         :param parameter: The parameter to create a schema for
         :param index: The index of the parameter in the function signature
         :param docstring: The docstring for the function containing the parameter
         """
+        self.type_schema = type_schema
         self.parameter: Parameter = parameter
         self.index: int = index
         self.config: Config = config
         self.docstring: str = docstring
 
     @staticmethod
-    def matches(parameter: Parameter) -> bool:
+    def create(
+        parameter: Parameter, index: int, config: Config, docstring: str = None
+    ) -> Optional[ParameterSchema]:
         """
-        Determine if this schema can be used for the given parameter.
+        Create a new parameter schema for the specified parameter.
 
-        :return: True if this schema can be used to parse the given parameter;
+        :return: An instance of `ParameterSchema`, or None if the parameter type is not supported.
         """
-        raise NotImplementedError()
-
-    def _get_type(self) -> Union[str, Parameter.empty]:
-        """
-        Get the type of this parameter, to be added to the JSON schema.
-        Return `Parameter.empty` to omit the type from the schema.
-        """
-        return Parameter.empty
-
-    def _get_items(self) -> Union[str, Parameter.empty]:
-        """
-        Get the items property to be added to the JSON schema.
-        Return `Parameter.empty` to omit the items from the schema.
-        """
-        return Parameter.empty
-
-    def _get_enum(self) -> Union[list[str], Parameter.empty]:
-        """
-        Get the enum property to be added to the JSON schema.
-        Return `Parameter.empty` to omit the enum from the schema.
-        """
-        return Parameter.empty
+        if type_schema := TypeSchema.create(parameter.annotation):
+            return ParameterSchema(type_schema, parameter, index, config, docstring)
 
     def _get_description(self) -> Union[str, Parameter.empty]:
         """
@@ -87,7 +71,7 @@ class ParameterSchema:
         Return `Parameter.empty` to omit the default value from the schema.
         """
         if self.parameter.default != Parameter.empty:
-            return self.encode_value(self.parameter.default)
+            return self.type_schema.encode(self.parameter.default)
 
         # Not that the default value may be present but None, we use
         # Parameter.empty to indicate that the default value is not present
@@ -100,184 +84,20 @@ class ParameterSchema:
         fields = {
             "description": self._get_description(),
             "default": self._get_default(),
-            "items": self._get_items(),
-            "type": self._get_type(),
-            "enum": self._get_enum(),
+            **self.type_schema.to_json(),
         }
 
         json = {f: v for f, v in fields.items() if v != Parameter.empty}
 
         return json
 
-    def encode_value(self, value):
-        """
-        Convert the given value to its JSON representation. Overriding methods should
-        also override `decode_value` to convert the value back to its original type.
-
-        :param value: The value to be converted
-        :return: The JSON representation of the value
-        """
-        return value
-
-    def decode_value(self, value):
-        """
-        Convert the given value from the JSON representation to an instance
-        that can be passed to the original method as a parameter. Overriding
-        methods should check whether the value needs to be converted, and return
-        it as is if no conversion is necessary.
-
-        :param value: The value to be converted
-        :return: An instance of the type required by the original method
-        """
-        return value
-
-
-class ValueTypeSchema(ParameterSchema):
-    """
-    Parameter schema for value types.
-    """
-
-    @staticmethod
-    def matches(parameter: Parameter) -> bool:
-        return parameter.annotation != Parameter.empty and parameter.annotation.__name__ in TYPE_MAP
-
-    def _get_type(self) -> Union[str, Parameter.empty]:
-        return TYPE_MAP[self.parameter.annotation.__name__]
-
-
-class GenericParameterSchema(ParameterSchema):
-    """
-    Base class for generic parameter types supporting subscription.
-    """
-
-    def _get_sub_type(self) -> Union[str, Parameter.empty]:
-        if args := typing.get_args(self.parameter.annotation):
-            return TYPE_MAP.get(args[0].__name__, "object")
-
-        return Parameter.empty
-
-
-class ListTypeParameterSchema(GenericParameterSchema):
-    """
-    Parameter schema for list (array) types.
-    """
-
-    @staticmethod
-    def matches(parameter: Parameter) -> bool:
-        return parameter.annotation != Parameter.empty and (
-            parameter.annotation is list or typing.get_origin(parameter.annotation) is list
-        )
-
-    def _get_type(self) -> Union[str, Parameter.empty]:
-        return TYPE_MAP["list"]
-
-    def _get_items(self) -> Union[str, Parameter.empty]:
-        if (sub_type := super()._get_sub_type()) != Parameter.empty:
-            return {"type": sub_type}
-
-        return Parameter.empty
-
-
-class OptionalTypeParameterSchema(GenericParameterSchema):
-    """
-    Parameter schema for typing.Optional types.
-    """
-
-    @staticmethod
-    def matches(parameter: Parameter) -> bool:
-        args = typing.get_args(parameter.annotation)
-        return (
-            parameter.annotation != parameter.empty
-            and typing.get_origin(parameter.annotation) is Union
-            and len(args) == 2
-            and type(None) in args
-        )
-
-    def _get_type(self) -> Union[str, Parameter.empty]:
-        return super()._get_sub_type()
-
 
 class EnumParameterSchema(ParameterSchema):
     """
-    Parameter schema for enumeration types.
+    Parameter schema for enumeration types manually added via add_enum.
     """
 
     def __init__(
         self, values: list, parameter: Parameter, index: int, config: Config, docstring: str = None
     ):
-        super().__init__(parameter, index, config, docstring)
-        self.enum_values = values
-
-    def _get_type(self) -> Union[str, Parameter.empty]:
-        return TYPE_MAP.get(type(self.enum_values[0]).__name__, "object")
-
-    def _get_enum(self) -> Union[list[str], Parameter.empty]:
-        return self.enum_values
-
-
-class EnumTypeParameterSchema(EnumParameterSchema):
-    """
-    Parameter schema for enum.Enum types.
-    """
-
-    def __init__(self, parameter: Parameter, index: int, config: Config, docstring: str = None):
-        values = [e.name for e in parameter.annotation]
-        super().__init__(values, parameter, index, config, docstring)
-
-    @staticmethod
-    def matches(parameter: Parameter) -> bool:
-        return (
-            parameter.annotation != parameter.empty
-            and isclass(parameter.annotation)
-            and issubclass(parameter.annotation, Enum)
-        )
-
-    def encode_value(self, value):
-        """
-        Convert an enum instance to its name.
-
-        :param value: The enum instance to be converted.
-        """
-        return value.name if isinstance(value, Enum) else value
-
-    def decode_value(self, value):
-        """
-        Convert an enum name to an instance of the enum type.
-
-        :param value: The enum name to be converted
-        """
-        if value in self.enum_values:
-            # Convert to an enum instance
-            return self.parameter.annotation[value]
-
-        # The user is invoking the method directly
-        return value
-
-
-class LiteralTypeParameterSchema(EnumParameterSchema):
-    """
-    Parameter schema for typing.Literal types.
-    """
-
-    def __init__(self, parameter: Parameter, index: int, config: Config, docstring: str = None):
-        values = list(typing.get_args(parameter.annotation))
-        super().__init__(values, parameter, index, config, docstring)
-
-    @staticmethod
-    def matches(parameter: Parameter) -> bool:
-        return (
-            parameter.annotation != parameter.empty
-            and typing.get_origin(parameter.annotation) is typing.Literal
-        )
-
-
-# Order matters: specific classes should appear before more generic ones;
-# for example, ListParameterSchema must precede ValueTypeSchema,
-# as they both match list types
-PARAMETER_SCHEMAS = [
-    OptionalTypeParameterSchema,
-    LiteralTypeParameterSchema,
-    EnumTypeParameterSchema,
-    ListTypeParameterSchema,
-    ValueTypeSchema,
-]
+        super().__init__(EnumTypeSchema(values), parameter, index, config, docstring)

--- a/tool2schema/parameter_schema.py
+++ b/tool2schema/parameter_schema.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import re
 from inspect import Parameter
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from tool2schema import Config
 from tool2schema.type_schema import EnumTypeSchema, TypeSchema
@@ -20,7 +20,7 @@ class ParameterSchema:
         parameter: Parameter,
         index: int,
         config: Config,
-        docstring: str = None,
+        docstring: Optional[str] = None,
     ):
         """
         Create a new parameter schema.
@@ -32,22 +32,22 @@ class ParameterSchema:
         :param docstring: The docstring for the function containing the parameter
         """
         self.type_schema = type_schema
-        self.parameter: Parameter = parameter
-        self.index: int = index
-        self.config: Config = config
-        self.docstring: str = docstring
+        self.parameter = parameter
+        self.index = index
+        self.config = config
+        self.docstring = docstring
 
     @staticmethod
     def create(
-        parameter: Parameter, index: int, config: Config, docstring: str = None
+        parameter: Parameter, index: int, config: Config, docstring: Optional[str] = None
     ) -> Optional[ParameterSchema]:
         """
         Create a new parameter schema for the specified parameter.
 
         :param parameter: The parameter to create a schema for
         :param index: The index of the parameter in the function signature
-        :param docstring: The docstring for the function containing the parameter
         :param config: Configuration settings to use when creating the schema
+        :param docstring: The docstring for the function containing the parameter
         :return: An instance of `ParameterSchema`, or None if the parameter type is not supported.
         """
         if type_schema := TypeSchema.create(parameter.annotation):
@@ -70,7 +70,7 @@ class ParameterSchema:
 
         return Parameter.empty
 
-    def _get_default(self) -> any:
+    def _get_default(self) -> Any:
         """
         Get the default value for this parameter, when present, to be added to the JSON schema.
         Return `Parameter.empty` to omit the default value from the schema.

--- a/tool2schema/parameter_schema.py
+++ b/tool2schema/parameter_schema.py
@@ -82,6 +82,14 @@ class ParameterSchema:
         # Parameter.empty to indicate that the default value is not present
         return Parameter.empty
 
+    def add_enum(self, values: list) -> None:
+        """
+        Convert this parameter to an enumeration type.
+
+        :param values: List of unique enumeration values.
+        """
+        self.type_schema = EnumTypeSchema(values)
+
     def to_json(self) -> dict:
         """
         Return the json schema for this parameter.
@@ -95,14 +103,3 @@ class ParameterSchema:
         json = {f: v for f, v in fields.items() if v != Parameter.empty}
 
         return json
-
-
-class EnumParameterSchema(ParameterSchema):
-    """
-    Parameter schema for enumeration types manually added via add_enum.
-    """
-
-    def __init__(
-        self, values: list, parameter: Parameter, index: int, config: Config, docstring: str = None
-    ):
-        super().__init__(EnumTypeSchema(values), parameter, index, config, docstring)

--- a/tool2schema/schema.py
+++ b/tool2schema/schema.py
@@ -171,7 +171,7 @@ class FunctionSchema:
 
         if self.parameter_schemas or schema_type == SchemaType.TUNE:
             # If the schema type is tune, add the dictionary even if there are no parameters
-            schema["parameters"] = self._get_parameters_schema(schema_type)
+            schema["parameters"] = self._get_parameters_schema()
 
         if (description := self._get_description()) is not None:
             # Add the function description even if it is an empty string
@@ -179,18 +179,11 @@ class FunctionSchema:
 
         return schema
 
-    def _get_parameters_schema(self, schema_type: SchemaType) -> dict:
+    def _get_parameters_schema(self) -> dict:
         """
         Get the parameters schema dictionary.
         """
-        schema = {"type": "object"}
-
-        if not self.parameter_schemas and schema_type == SchemaType.API:
-            # Skip properties
-            return schema
-
-        # If the schema type is tune, add the dictionary even if empty
-        schema["properties"] = self._get_parameter_properties_schema()
+        schema = {"type": "object", "properties": self._get_parameter_properties_schema()}
 
         if required := self._get_required_parameters():
             schema["required"] = required

--- a/tool2schema/schema.py
+++ b/tool2schema/schema.py
@@ -9,7 +9,7 @@ from typing import Callable, Optional
 
 import tool2schema
 from tool2schema.config import Config
-from tool2schema.parameter_schema import EnumParameterSchema, ParameterSchema
+from tool2schema.parameter_schema import ParameterSchema
 
 
 class SchemaType(Enum):
@@ -150,10 +150,7 @@ class FunctionSchema:
         :param n: The name of the parameter with the enum values
         :param enum: The list of values for the enum parameter
         """
-        p = self._all_parameter_schemas[n]
-        self._all_parameter_schemas[n] = EnumParameterSchema(
-            enum, p.parameter, p.index, self.config, p.docstring
-        )
+        self._all_parameter_schemas[n].add_enum(enum)
         return self
 
     def _get_schema(self) -> dict:

--- a/tool2schema/type_schema.py
+++ b/tool2schema/type_schema.py
@@ -1,0 +1,268 @@
+from __future__ import annotations
+
+import typing
+from enum import Enum
+from inspect import Parameter, isclass
+from typing import Literal, Optional, Type, Union
+
+# Order matters: specific classes should appear before more generic ones,
+# because the first matching schema will be used
+TYPE_SCHEMAS = []
+
+
+def GPTTypeSchema(cls):
+    """
+    Decorator to register a type schema class.
+    """
+    TYPE_SCHEMAS.insert(0, cls)  # Push to the front
+    return cls
+
+
+class TypeSchema:
+    """
+    Base class for type converters.
+    """
+
+    def __init__(self, p_type: Optional[Type] = None):
+        # The type can be none if the type was created manually, for example
+        # via the add_enum method which creates an instance of EnumTypeSchema
+        self.type: Optional[Type] = p_type
+
+    @staticmethod
+    def create(p_type) -> Optional[TypeSchema]:
+        """
+        Create a new schema for the given type.
+        """
+        for schema in TYPE_SCHEMAS:
+            if schema.matches(p_type):
+                return schema(p_type)
+
+    @staticmethod
+    def matches(p_type: Type) -> bool:
+        """
+        Determine if this schema can be used for the given type.
+
+        :return: True if this schema can be used to parse the given type
+        """
+        raise NotImplementedError()
+
+    def encode(self, value):
+        """
+        Convert the given value to its JSON representation. Overriding methods should
+        also override `decode` to convert the value back to its original type.
+
+        :param value: The value to be converted
+        :return: The JSON representation of the value
+        """
+        return value
+
+    def decode(self, value):
+        """
+        Convert the given value from the JSON representation to an instance
+        that can be passed to the original method as a parameter. Overriding
+        methods should check whether the value needs to be converted, and return
+        it as is if no conversion is necessary.
+
+        :param value: The value to be converted
+        :return: An instance of the type required by the original method
+        """
+        return value
+
+    def _get_type(self) -> Union[str, Parameter.empty]:
+        """
+        Get the type to be added to the JSON schema.
+        Return `Parameter.empty` to omit the type from the schema.
+        """
+        return Parameter.empty
+
+    def _get_items(self) -> Union[str, Parameter.empty]:
+        """
+        Get the items property to be added to the JSON schema.
+        Return `Parameter.empty` to omit the items from the schema.
+        """
+        return Parameter.empty
+
+    def _get_enum(self) -> Union[list[str], Parameter.empty]:
+        """
+        Get the enum property to be added to the JSON schema.
+        Return `Parameter.empty` to omit the enum from the schema.
+        """
+        return Parameter.empty
+
+    def to_json(self) -> dict:
+        """
+        Return the json schema for this type.
+        """
+        fields = {
+            "type": self._get_type(),
+            "items": self._get_items(),
+            "enum": self._get_enum(),
+        }
+
+        return {f: v for f, v in fields.items() if v != Parameter.empty}
+
+
+@GPTTypeSchema
+class ValueTypeSchema(TypeSchema):
+    """
+    Type schema for value types.
+    """
+
+    TYPE_MAP = {
+        "int": "integer",
+        "float": "number",
+        "str": "string",
+        "bool": "boolean",
+    }
+
+    @staticmethod
+    def matches(p_type) -> bool:
+        return True
+
+    def _get_type(self) -> Union[str, Parameter.empty]:
+        return self.TYPE_MAP.get(self.type.__name__, "object")
+
+
+class GenericTypeSchema(TypeSchema):
+    """
+    Base class for generic types supporting subscription.
+    """
+
+    def _get_sub_type(self) -> Union[TypeSchema, Parameter.empty]:
+        if args := typing.get_args(self.type):
+            return TypeSchema.create(args[0])
+
+        return Parameter.empty
+
+
+@GPTTypeSchema
+class ListTypeSchema(GenericTypeSchema):
+    """
+    Type schema for list (array) types, including typing.List.
+    """
+
+    @staticmethod
+    def matches(p_type):
+        return p_type != Parameter.empty and (p_type is list or typing.get_origin(p_type) is list)
+
+    def _get_type(self) -> Union[str, Parameter.empty]:
+        return "array"
+
+    def _get_items(self) -> Union[str, Parameter.empty]:
+        if (sub_type := self._get_sub_type()) != Parameter.empty:
+            return {"type": sub_type._get_type()}
+
+        return Parameter.empty
+
+    def encode(self, value):
+        if (sub_type := self._get_sub_type()) != Parameter.empty:
+            return [sub_type.encode(v) for v in value]
+
+        return value
+
+    def decode(self, value):
+        if (sub_type := self._get_sub_type()) != Parameter.empty:
+            return [sub_type.decode(v) for v in value]
+
+        return value
+
+
+@GPTTypeSchema
+class OptionalTypeSchema(GenericTypeSchema):
+    """
+    Type schema for typing.Optional types.
+    """
+
+    @staticmethod
+    def matches(p_type: Type) -> bool:
+        args = typing.get_args(p_type)
+        return (
+            p_type != Parameter.empty
+            and typing.get_origin(p_type) is Union
+            and len(args) == 2
+            and type(None) in args
+        )
+
+    def _get_type(self) -> Union[str, Parameter.empty]:
+        return super()._get_sub_type()._get_type()
+
+    def _get_enum(self) -> Union[str, Parameter.empty]:
+        return super()._get_sub_type()._get_enum()
+
+    def encode(self, value):
+        if value is None:
+            return value
+
+        return self._get_sub_type().encode(value)
+
+    def decode(self, value):
+        if value is None:
+            return value
+
+        return self._get_sub_type().decode(value)
+
+
+class EnumTypeSchema(TypeSchema):
+    """
+    Base type schema form enumeration types.
+    """
+
+    def __init__(self, enum_values, type: Optional[Type] = None):
+        super().__init__(type)
+        self.enum_values = enum_values
+
+    def _get_type(self) -> Union[str, Parameter.empty]:
+        return TypeSchema.create(type(self.enum_values[0]))._get_type()
+
+    def _get_enum(self) -> Union[list[str], Parameter.empty]:
+        return self.enum_values
+
+
+@GPTTypeSchema
+class EnumClassTypeSchema(EnumTypeSchema):
+    """
+    Type schema for enum.Enum types.
+    """
+
+    def __init__(self, p_type: Enum):
+        super().__init__([e.name for e in p_type], p_type)
+
+    @staticmethod
+    def matches(type_p) -> bool:
+        return type_p != Parameter.empty and isclass(type_p) and issubclass(type_p, Enum)
+
+    def encode(self, value):
+        """
+        Convert an enum instance to its name.
+
+        :param value: The enum instance to be converted.
+        """
+        return value.name if isinstance(value, Enum) else value
+
+    def decode(self, value):
+        """
+        Convert an enum name to an instance of the enum type.
+
+        :param value: The enum name to be converted
+        """
+        if value in self.enum_values:
+            # Convert to an enum instance
+            return self.type[value]
+
+        # The user is invoking the method directly passing the enum instance
+        return value
+
+
+@GPTTypeSchema
+class LiteralTypeSchema(EnumTypeSchema):
+    """
+    Type schema for typing.Literal types.
+    """
+
+    def __init__(self, p_type):
+        values = list(typing.get_args(p_type))
+        super().__init__(values, p_type)
+
+    @staticmethod
+    def matches(p_type: Type) -> bool:
+        return p_type != Parameter.empty and typing.get_origin(p_type) is Literal

--- a/tool2schema/type_schema.py
+++ b/tool2schema/type_schema.py
@@ -7,10 +7,10 @@ from typing import Literal, Optional, Type, Union
 
 # Order matters: specific classes should appear before more generic ones,
 # because the first matching schema will be used
-TYPE_SCHEMAS = []
+TYPE_SCHEMAS: list[Type[TypeSchema]] = []
 
 
-def GPTTypeSchema(cls):
+def GPTTypeSchema(cls: Type[TypeSchema]):
     """
     Decorator to register a type schema class.
     """
@@ -26,7 +26,7 @@ class TypeSchema:
     def __init__(self, p_type: Optional[Type] = None):
         # The type can be none if the type was created manually, for example
         # via the add_enum method which creates an instance of EnumTypeSchema
-        self.type: Optional[Type] = p_type
+        self.type = p_type
 
     @staticmethod
     def create(p_type: Type) -> Optional[TypeSchema]:

--- a/tool2schema/type_schema.py
+++ b/tool2schema/type_schema.py
@@ -77,14 +77,14 @@ class TypeSchema:
         """
         return Parameter.empty
 
-    def _get_items(self) -> Union[str, Parameter.empty]:
+    def _get_items(self) -> Union[dict, Parameter.empty]:
         """
         Get the items property to be added to the JSON schema.
         Return `Parameter.empty` to omit the items from the schema.
         """
         return Parameter.empty
 
-    def _get_enum(self) -> Union[list[str], Parameter.empty]:
+    def _get_enum(self) -> Union[list, Parameter.empty]:
         """
         Get the enum property to be added to the JSON schema.
         Return `Parameter.empty` to omit the enum from the schema.
@@ -144,13 +144,13 @@ class ListTypeSchema(GenericTypeSchema):
     """
 
     @staticmethod
-    def matches(p_type):
+    def matches(p_type: Type) -> bool:
         return p_type != Parameter.empty and (p_type is list or typing.get_origin(p_type) is list)
 
     def _get_type(self) -> Union[str, Parameter.empty]:
         return "array"
 
-    def _get_items(self) -> Union[str, Parameter.empty]:
+    def _get_items(self) -> Union[dict, Parameter.empty]:
         if (sub_type := self._get_sub_type()) != Parameter.empty:
             return sub_type.to_json()
 
@@ -188,7 +188,7 @@ class OptionalTypeSchema(GenericTypeSchema):
     def _get_type(self) -> Union[str, Parameter.empty]:
         return super()._get_sub_type()._get_type()
 
-    def _get_enum(self) -> Union[str, Parameter.empty]:
+    def _get_enum(self) -> Union[list, Parameter.empty]:
         return super()._get_sub_type()._get_enum()
 
     def encode(self, value):
@@ -216,7 +216,7 @@ class EnumTypeSchema(TypeSchema):
     def _get_type(self) -> Union[str, Parameter.empty]:
         return TypeSchema.create(type(self.enum_values[0]))._get_type()
 
-    def _get_enum(self) -> Union[list[str], Parameter.empty]:
+    def _get_enum(self) -> Union[list, Parameter.empty]:
         return self.enum_values
 
 
@@ -230,7 +230,7 @@ class EnumClassTypeSchema(EnumTypeSchema):
         super().__init__([e.name for e in p_type], p_type)
 
     @staticmethod
-    def matches(type_p) -> bool:
+    def matches(type_p: Type) -> bool:
         return type_p != Parameter.empty and isclass(type_p) and issubclass(type_p, Enum)
 
     def encode(self, value):

--- a/tool2schema/type_schema.py
+++ b/tool2schema/type_schema.py
@@ -29,9 +29,11 @@ class TypeSchema:
         self.type: Optional[Type] = p_type
 
     @staticmethod
-    def create(p_type) -> Optional[TypeSchema]:
+    def create(p_type: Type) -> Optional[TypeSchema]:
         """
         Create a new schema for the given type.
+
+        :return: An instance of `TypeSchema`, or None if the type is not supported.
         """
         for schema in TYPE_SCHEMAS:
             if schema.matches(p_type):
@@ -150,7 +152,7 @@ class ListTypeSchema(GenericTypeSchema):
 
     def _get_items(self) -> Union[str, Parameter.empty]:
         if (sub_type := self._get_sub_type()) != Parameter.empty:
-            return {"type": sub_type._get_type()}
+            return sub_type.to_json()
 
         return Parameter.empty
 


### PR DESCRIPTION
In order to support lists of enumeration types and, in general, nested types (such as `Optional[MyEnum]`) I think it is necessary to divide the parameter class from the type-parser class.

In this way, a type parser such as `ListTypeSchema` can instantiate a type parser such as `EnumClassTypeSchema` and delegate to it the job of deducing the type, encoding/decoding values and so on:

```python
class ListTypeSchema(GenericTypeSchema):
    # ...
    
    def _get_type(self) -> Union[str, Parameter.empty]:
        return "array"

    def _get_items(self) -> Union[str, Parameter.empty]:
        if (sub_type := self._get_sub_type()) != Parameter.empty:
            return {"type": sub_type._get_type()} # <---- sub_type is a TypeSchema instance

        return Parameter.empty
```