### PR TITLE
Improve intellisense support #58

### DIFF
--- a/tool2schema/schema.py
+++ b/tool2schema/schema.py
@@ -28,7 +28,7 @@ class SchemaType(Enum):
     TUNE = 1
 
 
-def FindGPTEnabled(module: ModuleType) -> list[_GPTEnabled]:
+def FindGPTEnabled(module: ModuleType) -> list[ToolEnabled]:
     """
     Find all functions with the GPTEnabled decorator.
 
@@ -49,7 +49,7 @@ def FindGPTEnabledSchemas(
     return [x.schema.to_json(schema_type) for x in FindGPTEnabled(module)]
 
 
-def FindGPTEnabledByName(module: ModuleType, name: str) -> Optional[_GPTEnabled]:
+def FindGPTEnabledByName(module: ModuleType, name: str) -> Optional[ToolEnabled]:
     """
     Find a function with the GPTEnabled decorator by name.
 
@@ -62,7 +62,7 @@ def FindGPTEnabledByName(module: ModuleType, name: str) -> Optional[_GPTEnabled]
     return None
 
 
-def FindGPTEnabledByTag(module: ModuleType, tag: str) -> list[_GPTEnabled]:
+def FindGPTEnabledByTag(module: ModuleType, tag: str) -> list[ToolEnabled]:
     """
     Find all functions with the GPTEnabled decorator by tag.
 
@@ -199,7 +199,7 @@ P = ParamSpec("P")  # User-provided function parameters type
 T = TypeVar("T")  # User-provided function return type
 
 
-class _GPTEnabled(Generic[P, T]):
+class ToolEnabled(Generic[P, T]):
     def __init__(self, func: Callable[P, T], **kwargs) -> None:
         self.func = func
         self.tags = kwargs.pop("tags", [])
@@ -233,14 +233,14 @@ class _GPTEnabled(Generic[P, T]):
 
 def GPTEnabled(
     func: Callable[P, T] = None, **kwargs
-) -> Union[_GPTEnabled[P, T], Callable[[Callable[P, T]], _GPTEnabled[P, T]]]:
+) -> Union[ToolEnabled[P, T], Callable[[Callable[P, T]], ToolEnabled[P, T]]]:
     """Decorator to generate a function schema for OpenAI."""
     if func:
-        return _GPTEnabled(func, **kwargs)
+        return ToolEnabled(func, **kwargs)
     else:
 
-        def wrapper(function: Callable[P, T]) -> _GPTEnabled[P, T]:
-            return _GPTEnabled(function, **kwargs)
+        def wrapper(function: Callable[P, T]) -> ToolEnabled[P, T]:
+            return ToolEnabled(function, **kwargs)
 
         return wrapper
 

--- a/tool2schema/schema.py
+++ b/tool2schema/schema.py
@@ -9,7 +9,7 @@ import sys
 from enum import Enum
 from inspect import Parameter
 from types import ModuleType
-from typing import Any, Callable, Generic, Optional, TypeVar, Union
+from typing import Any, Callable, Generic, Optional, TypeVar, overload
 
 import tool2schema
 from tool2schema.config import Config
@@ -231,11 +231,19 @@ class ToolEnabled(Generic[P, T]):
         return tag in self.tags
 
 
-def GPTEnabled(
-    func: Optional[Callable[P, T]] = None, **kwargs
-) -> Union[ToolEnabled[P, T], Callable[[Callable[P, T]], ToolEnabled[P, T]]]:
+@overload
+def GPTEnabled(func: Callable[P, T], **kwargs) -> ToolEnabled[P, T]:
+    ...
+
+
+@overload
+def GPTEnabled(**kwargs) -> Callable[[Callable[P, T]], ToolEnabled[P, T]]:
+    ...
+
+
+def GPTEnabled(func = None, **kwargs):
     """Decorator to generate a function schema for OpenAI."""
-    if func:
+    if func is not None:
         return ToolEnabled(func, **kwargs)
     else:
 

--- a/tool2schema/schema.py
+++ b/tool2schema/schema.py
@@ -161,7 +161,7 @@ def LoadGPTEnabled(
     return f, arguments
 
 
-def _validate_arguments(f: Callable, arguments: dict, ignore_hallucinations: bool) -> dict:
+def _validate_arguments(f: ToolEnabled, arguments: dict, ignore_hallucinations: bool) -> dict:
     """
     Verify that all required arguments are present, and the arguments are of the expected type.
     Raise an exception if any of these conditions is not met, or if there are any hallucinated
@@ -207,6 +207,10 @@ class ToolEnabled(Generic[P, T]):
         self.schema = FunctionSchema(func, self.config)
         functools.update_wrapper(self, func)
 
+    @property
+    def __name__(self) -> str:
+        return self.func.__name__
+
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T:
 
         args = list(args)  # Tuple is immutable, thus convert to list
@@ -232,7 +236,7 @@ class ToolEnabled(Generic[P, T]):
 
 
 def GPTEnabled(
-    func: Callable[P, T] = None, **kwargs
+    func: Optional[Callable[P, T]] = None, **kwargs
 ) -> Union[ToolEnabled[P, T], Callable[[Callable[P, T]], ToolEnabled[P, T]]]:
     """Decorator to generate a function schema for OpenAI."""
     if func:
@@ -291,7 +295,7 @@ class FunctionSchema:
         """
         Get the function schema dictionary.
         """
-        schema = {"name": self.f.__name__}
+        schema: dict[str, Any] = {"name": self.f.__name__}
 
         if self.parameter_schemas or schema_type == SchemaType.TUNE:
             # If the schema type is tune, add the dictionary even if there are no parameters

--- a/tool2schema/schema.py
+++ b/tool2schema/schema.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import functools
 import inspect
@@ -6,7 +8,7 @@ import re
 from enum import Enum
 from inspect import Parameter
 from types import ModuleType
-from typing import Callable, Optional
+from typing import Callable, Optional, Union
 
 import tool2schema
 from tool2schema.config import Config
@@ -219,7 +221,9 @@ class _GPTEnabled:
         return tag in self.tags
 
 
-def GPTEnabled(func=None, **kwargs):
+def GPTEnabled(
+    func: Callable = None, **kwargs
+) -> Union[_GPTEnabled, Callable[[Callable], _GPTEnabled]]:
     """Decorator to generate a function schema for OpenAI."""
     if func:
         return _GPTEnabled(func, **kwargs)
@@ -255,12 +259,13 @@ class FunctionSchema:
 
         return self._get_schema()
 
-    def add_enum(self, n: str, enum: list) -> "FunctionSchema":
+    def add_enum(self, n: str, enum: list) -> FunctionSchema:
         """
         Add enum property to a particular function parameter.
 
         :param n: The name of the parameter with the enum values
         :param enum: The list of values for the enum parameter
+        :return: This function schema
         """
         self._all_parameter_schemas[n].add_enum(enum)
         return self

--- a/tool2schema/schema.py
+++ b/tool2schema/schema.py
@@ -232,13 +232,11 @@ class ToolEnabled(Generic[P, T]):
 
 
 @overload
-def GPTEnabled(func: Callable[P, T], **kwargs) -> ToolEnabled[P, T]:
-    ...
+def GPTEnabled(func: Callable[P, T], **kwargs) -> ToolEnabled[P, T]: ...
 
 
 @overload
-def GPTEnabled(**kwargs) -> Callable[[Callable[P, T]], ToolEnabled[P, T]]:
-    ...
+def GPTEnabled(**kwargs) -> Callable[[Callable[P, T]], ToolEnabled[P, T]]: ...
 
 
 def GPTEnabled(func=None, **kwargs):

--- a/tool2schema/schema.py
+++ b/tool2schema/schema.py
@@ -5,14 +5,20 @@ import functools
 import inspect
 import json
 import re
+import sys
 from enum import Enum
 from inspect import Parameter
 from types import ModuleType
-from typing import Any, Callable, Generic, Optional, ParamSpec, TypeVar, Union
+from typing import Any, Callable, Generic, Optional, TypeVar, Union
 
 import tool2schema
 from tool2schema.config import Config
 from tool2schema.parameter_schema import ParameterSchema
+
+if sys.version_info < (3, 10):
+    from typing_extensions import ParamSpec
+else:
+    from typing import ParamSpec
 
 
 class SchemaType(Enum):
@@ -22,7 +28,7 @@ class SchemaType(Enum):
     TUNE = 1
 
 
-def FindGPTEnabled(module: ModuleType) -> list[Callable]:
+def FindGPTEnabled(module: ModuleType) -> list[_GPTEnabled]:
     """
     Find all functions with the GPTEnabled decorator.
 
@@ -43,7 +49,7 @@ def FindGPTEnabledSchemas(
     return [x.schema.to_json(schema_type) for x in FindGPTEnabled(module)]
 
 
-def FindGPTEnabledByName(module: ModuleType, name: str) -> Optional[Callable]:
+def FindGPTEnabledByName(module: ModuleType, name: str) -> Optional[_GPTEnabled]:
     """
     Find a function with the GPTEnabled decorator by name.
 
@@ -56,7 +62,7 @@ def FindGPTEnabledByName(module: ModuleType, name: str) -> Optional[Callable]:
     return None
 
 
-def FindGPTEnabledByTag(module: ModuleType, tag: str) -> list[Callable]:
+def FindGPTEnabledByTag(module: ModuleType, tag: str) -> list[_GPTEnabled]:
     """
     Find all functions with the GPTEnabled decorator by tag.
 

--- a/tool2schema/schema.py
+++ b/tool2schema/schema.py
@@ -8,7 +8,7 @@ import re
 from enum import Enum
 from inspect import Parameter
 from types import ModuleType
-from typing import Callable, Optional, Union, ParamSpec, TypeVar, Generic
+from typing import Callable, Generic, Optional, ParamSpec, TypeVar, Union
 
 import tool2schema
 from tool2schema.config import Config

--- a/tool2schema/schema.py
+++ b/tool2schema/schema.py
@@ -207,10 +207,6 @@ class ToolEnabled(Generic[P, T]):
         self.schema = FunctionSchema(func, self.config)
         functools.update_wrapper(self, func)
 
-    @property
-    def __name__(self) -> str:
-        return self.func.__name__
-
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T:
 
         args = list(args)  # Tuple is immutable, thus convert to list

--- a/tool2schema/schema.py
+++ b/tool2schema/schema.py
@@ -241,7 +241,7 @@ def GPTEnabled(**kwargs) -> Callable[[Callable[P, T]], ToolEnabled[P, T]]:
     ...
 
 
-def GPTEnabled(func = None, **kwargs):
+def GPTEnabled(func=None, **kwargs):
     """Decorator to generate a function schema for OpenAI."""
     if func is not None:
         return ToolEnabled(func, **kwargs)


### PR DESCRIPTION
Now intellisense should understand the type of `my_function.schema` and as a consequence also suggest arguments for add_enum.

The annotation (unfortunately a little verbose) should have done the trick:
```python
def GPTEnabled(
    func: Callable = None, **kwargs
) -> Union[_GPTEnabled, Callable[[Callable], _GPTEnabled]]:
```

I also removed the quotas from the return annotation in `add_enum` by importing future annotations and added `return` to the docstring. 

@siliconlad let me know if it works on your end as well :)